### PR TITLE
[BUG-FIX]: using actual program exit codes

### DIFF
--- a/pico8-cli/Program.cs
+++ b/pico8-cli/Program.cs
@@ -81,7 +81,7 @@ namespace pico8_cli
 
             LogInstallAndLocationInfos();
 
-            return result == CommandState.SUCCESS ? 1 : -1;
+            return result == CommandState.SUCCESS ? 0 : 1;
         }
     }
 }


### PR DESCRIPTION
As requested in [this redit post](https://www.reddit.com/r/pico8/comments/x2oqtc/comment/in22rqd/?context=3) I implement the default programming exit codes 0 for sucess, 1 for an error